### PR TITLE
2.5.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,11 @@
         "psutil",
         "pyradios",
         "stationuuid"
+    ],
+    "grammarly.selectors": [
+        {
+            "language": "markdown",
+            "scheme": "file"
+        }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,27 @@
 ## 2.5.1
 
 1. Fixed RuntimeError with empty selection menu on no options provided to radio.
-2. Display current station name as a panel while starting the radio with `--uuid`
-3. Minor typo fixed in help message.
-4. Station names does not contain any unnecessary spaces now
-5. Do not play any station while `--flush` is given. Just delete the list and exit.
+2. Display the current station name as a panel while starting the radio with `--uuid`
+3. Minor typos were fixed in the help message.
+4. Station names do not contain any unnecessary spaces now
+5. Do not play any stations while `--flush` is given. Just delete the list and exit.
 
 ## 2.5.0
 
 1. Added a selection menu while no station information is provided. This will include the last played station and the favorite list.
-2. Added `--volume` option to the player. Now you can can pass volume level to the player.
-3. ffplay initialization errors handled. Better logic to stop the PID of ffplay
+2. Added `--volume` option to the player. Now you can pass the volume level to the player.
+3. `ffplay` initialization errors handled. Better logic to stop the PID of `ffplay`
 4. Some unhandled errors are now handled
 5. Minor typos fixed
-6. sentry-sdk added to gater errors (will be removed on next major release)
+6. `sentry-sdk` added to gater errors (will be removed on next major release)
 7. About section updated to show donation link
-8. Upgrade message will now point to this changelog file
+8. The upgrade message will now point to this changelog file
 9. Updated documentation
 
 ## 2.4.0
 
 1. Crashes on Windows fixed
-2. Fixed setup related issues (development purpose)
+Fixed setup-related issues (development purpose)
 
 ## 2.3.0
 
@@ -29,7 +29,7 @@
 2. Discover stations by state
 3. Discover stations by genre/tags
 4. Discover stations by language
-5. More info on multiple results for a stations name
+5. More info on multiple results for a station name
 6. Shows currently playing radio info as box
 7. sentry-SDK removed
 8. Help table improved
@@ -40,7 +40,7 @@
 1. Pretty Print welcome message using Rich
 2. More user-friendly and gorgeous
 3. Added several new options `-F`,`-W`,`-A`,`--flush`
-4. Fixed unhandled Exception when try to quit within 3 seconds
+4. Fixed unhandled Exception when trying to quit within 3 seconds
 5. Supports User-Added stations
 6. Alias file now supports both UUID and URL entry
 7. Fixed bugs in playing last station (which is actually an alias under fav list)
@@ -57,7 +57,7 @@
 
 ## 2.1.3
 
-1. Fixed bugs in last station
+1. Fixed bugs in the last station
 2. Typos fixed
 3. Formatted codebase
 4. Logging issued fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.5.1
+
+1. Fixed RuntimeError with empty selection menu on no options provided to radio.
+2. Display current station name as a panel while starting the radio with `--uuid`
+3. Minor typo fixed in help message.
+4. Station names does not contain any unnecessary spaces now
+5. Do not play any station while `--flush` is given. Just delete the list and exit.
+
 ## 2.5.0
 
 1. Added a selection menu while no station information is provided. This will include the last played station and the favorite list.
@@ -52,7 +60,7 @@
 1. Fixed bugs in last station
 2. Typos fixed
 3. Formatted codebase
-4. Logiing issued fixed
+4. Logging issued fixed
 5. Sentry Added to collect unhandled Exceptions logs only
 
 

--- a/radioactive/alias.py
+++ b/radioactive/alias.py
@@ -1,6 +1,7 @@
 import os.path
 from zenlog import log
 
+
 class Alias:
     def __init__(self):
         self.alias_map = []
@@ -67,6 +68,11 @@ class Alias:
 
     def flush(self):
         """deletes all the entries in the fav list"""
-        with open(self.alias_path, "w") as f:
-            f.flush()
-        log.info("All entries deleted in your favorite list")
+        try:
+            with open(self.alias_path, "w") as f:
+                f.flush()
+            log.info("All entries deleted in your favorite list")
+            return 0
+        except:
+            log.error("could not delete your favorite list. something went wrong")
+            return 1

--- a/radioactive/app.py
+++ b/radioactive/app.py
@@ -10,7 +10,7 @@ import requests
 
 class App:
     def __init__(self):
-        self.__VERSION__ = "2.5.0"  # change this on every update #
+        self.__VERSION__ = "2.5.1"  # change this on every update #
         self.pypi_api = "https://pypi.org/pypi/radio-active/json"
         self.remote_version = ""
 

--- a/radioactive/handler.py
+++ b/radioactive/handler.py
@@ -72,11 +72,13 @@ class Handler:
 
         # when exactly one response found
         if len(self.response) == 1:
-            log.info("Station found: {}".format(self.response[0]["name"]))
+            log.info("Station found: {}".format(self.response[0]["name"].strip()))
             log.debug(json.dumps(self.response[0], indent=3))
             self.target_station = self.response[0]
             # register a valid click to increase its popularity
             self.API.click_counter(self.target_station["stationuuid"])
+            # return name
+            return self.response[0]["name"].strip()
 
     def play_by_station_name(self, _name=None):
         """search and play a station by its name"""
@@ -90,7 +92,7 @@ class Handler:
     def play_by_station_uuid(self, _uuid):
         """search and play station by its stationuuid"""
         self.response = self.API.station_by_uuid(_uuid)
-        self.station_validator()
+        return self.station_validator() # should return a station name also
 
     def discover_by_country(self, _country_code, _limit):
         try:

--- a/radioactive/help.py
+++ b/radioactive/help.py
@@ -12,9 +12,10 @@ def show_help():
         """
         :radio: Play any radios around the globe right from this Terminal [yellow][blink]:zap:[/blink][/yellow]!
         :smile: Author: Dipankar Pal
-        :question: Type '--help' for more details on avaliable commands.
+        :question: Type '--help' for more details on available commands.
         :bug: Visit https://github.com/deep5050/radio-active to submit issues
         :star: Show some love by starring the project on GitHub [red][blink]:heart:[/blink][/red]
+        :dollar: You can donate me at https://deep5050.github.io/payme/
         """,
         title="[rgb(250,0,0)]RADIO[rgb(0,255,0)]ACTIVE",
         width=85,
@@ -31,12 +32,16 @@ def show_help():
     table.add_row(
         "--station , -S",
         "yes",
-        "A station name to play",
+        "A station name to search on the internet",
         "",
         "Optional from second run",
     )
     table.add_row(
-        "--uuid , -U", "yes", "A station UUID to play", "", "Optional from second run"
+        "--uuid , -U",
+        "yes",
+        "A station UUID to play it directly",
+        "",
+        "Optional from second run",
     )
     table.add_row(
         "--log-level , -L",
@@ -48,23 +53,22 @@ def show_help():
     table.add_row(
         "--add-station , -A",
         "no",
-        "Add a  station to your favourite list",
+        "Add a  station to your favorite list",
         "False",
         "Optional",
     )
     table.add_row(
-        "--add-to-favourite, -F ",
+        "--add-to-favorite, -F ",
         "yes",
-        "Add current station to favourite list with custom name",
+        "Add current station to favorite list with custom name",
         "False",
         "Optional",
     )
 
-
     table.add_row(
-        "--show-favourite-list, -W ",
+        "--show-favorite-list, -W ",
         "no",
-        "Show your favourite list",
+        "Show your favorite list",
         "False",
         "Optional",
     )
@@ -112,19 +116,11 @@ def show_help():
     table.add_row(
         "--volume",
         "yes",
-        "Volume of radio between 0 and 100",
+        "Volume of the radio between 0 and 100",
         "50",
         "Optional",
     )
 
-    table.add_row("--flush", "no", "Clear your favourite list", "False", "Optional")
-
-
-
-
-
-
-
-
+    table.add_row("--flush", "no", "Clear your favorite list", "False", "Optional")
 
     console.print(table)

--- a/radioactive/player.py
+++ b/radioactive/player.py
@@ -47,8 +47,8 @@ class Player:
                 self.is_playing = True
                 log.info("Radio started successfully")
             else:
-                log.error("Radio could not be stared, may be a dead station")
-                raise RuntimeError("Radio startup failed")
+                log.error("Radio could not be stared, may be a dead station. please try again")
+                sys.exit(1)
             
         except subprocess.CalledProcessError as e:
             log.error("Error while starting radio: {}".format(e))


### PR DESCRIPTION
- Fixed RuntimeError with empty selection menu on no options provided to radio.
- Display the current station name as a panel while starting the radio with --uuid
- Minor typos were fixed in the help message.
- Station names do not contain any unnecessary spaces now
- Do not play any stations while --flush is given. Just delete the list and exit.