### PR TITLE
pipx instead of pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ### Install
 
-Just run: `pip3 install --upgrade radio-active`
+Just run: `pipx install  radio-active`
 
 
 ### External Dependency


### PR DESCRIPTION
fixing the [pep 668](https://peps.python.org/pep-0668) . 
that is working fine to me and I thought a good idea to be on documentation 